### PR TITLE
Replace random() with non-POSIX rand() on Windows system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,7 @@ setup(name="ushuffle",
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
       ext_modules=extensions)

--- a/src/ushuffle.c
+++ b/src/ushuffle.c
@@ -40,7 +40,11 @@
 
 /* set random function */
 
-static randfunc_t randfunc = random;
+#if defined(_WIN32) || defined(_WIN64)
+	static randfunc_t randfunc = rand;
+#else
+	static randfunc_t randfunc = random;
+#endif
 
 void set_randfunc(randfunc_t func) {
 	randfunc = func;


### PR DESCRIPTION
The POSIX-compliant random() function is not available on Windows, which causes a compile-time error.

This PR fixes the issue by replacing random() with rand() on Windows systems, using macros `_WIN32` and `_WIN64` to detect Windows systems.

Additionally, the PyPI trove classifiers for Python 3.7 and 3.8 were added to `setup.py` after testing ushuffle with these versions.