### PR TITLE
fix: add Cython as build dependency to support Python > 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython>=0.29"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I depend on ushuffle in [SeqPro](https://github.com/ML4GLand/SeqPro) and have consistently been hitting CPython compilation errors with any version of Python > 3.8. A workaround has been to have Cython already installed before installing ushuffle. To avoid needing this, this PR adds a pyproject.toml that specifies Cython as a build dependency. This should also fix #9 and #10.